### PR TITLE
Normalize lead import exports

### DIFF
--- a/docs/plans/2026-03-08-leads-export-canonical-columns-design.md
+++ b/docs/plans/2026-03-08-leads-export-canonical-columns-design.md
@@ -1,0 +1,106 @@
+# Leads Export Canonical Columns Design
+
+**Date:** 2026-03-08
+**Status:** Approved
+**Owner:** Admin leads tooling
+
+## 1. Goal
+
+Make lead import downloads produce a consistent, cleaned CSV shape regardless of the original uploaded header names.
+
+## 2. Confirmed Product Decisions
+
+- Clean lead downloads must use this exact column order:
+  - `full name`
+  - `email`
+  - `tel`
+  - `answer`
+  - `date`
+  - `campaign`
+- Duplicate filtering remains unchanged.
+- Duplicate downloads should keep a `reason` column so admins can still see why a row was skipped.
+- Source files mainly come from Meta Ads style exports, so the alias mapper should favor common Meta header variants.
+
+## 3. Non-Goals
+
+- Changing the duplicate-detection rules.
+- Reworking the leads table schema.
+- Canonicalizing every payload key stored in the database.
+- Adding new UI beyond the existing import and download actions.
+
+## 4. Architecture
+
+1. Keep the database payload format as-is for now.
+2. Add a frontend export-normalization layer that maps messy source headers into canonical export fields.
+3. Reuse that same normalization path for:
+   - new imported leads downloads,
+   - duplicate leads downloads,
+   - historical batch downloads,
+   - stored file generation after import confirm.
+
+## 5. Field Mapping Rules
+
+### Full name
+
+- Prefer explicit full-name aliases such as `full name`, `full_name`, and `name`.
+- Otherwise combine first-name and last-name aliases such as `first name`, `first_name`, `last name`, and `last_name`.
+
+### Email
+
+- Use the lead row `email` field directly.
+
+### Tel
+
+- Support aliases such as `tel`, `telephone`, `telephone num`, `phone`, `phone number`, `phone_number`, and similar normalized variants from Meta-style exports.
+
+### Date
+
+- Support aliases such as `date`, `created_time`, `created at`, and `created_at`.
+
+### Campaign
+
+- Prefer campaign-like payload fields when present, including Meta-style campaign naming variants.
+- Fall back to the assigned campaign name from the app when the uploaded row does not include a campaign field.
+
+### Answer
+
+- Prefer direct aliases such as `answer`, `response`, and `reply`.
+- If none are present, infer the answer from the remaining non-system payload field that is most likely to represent the lead's answer. This should exclude obvious system columns such as ids, tracking columns, campaign columns, and contact fields.
+
+## 6. Data Flow
+
+### Upload and import
+
+- Admin uploads a CSV file.
+- Existing preview and confirm logic still parse the full row and keep duplicate filtering based on email.
+- The row continues to be stored as `email` plus raw payload JSON.
+
+### Download and storage
+
+- When building CSV text, the export helper converts each row into the canonical six-column shape.
+- Duplicate exports append `reason` after the six standard columns.
+- Stored clean and duplicate files use the same formatter, so fresh downloads and historical downloads stay consistent.
+
+## 7. Error Handling
+
+- If a canonical field cannot be found, export an empty string for that column.
+- If both full-name and first-name/last-name data exist, prefer the explicit full-name field to avoid accidental duplication.
+- If multiple possible answer fields exist, prefer explicit answer aliases before heuristic fallback.
+
+## 8. Testing Strategy
+
+1. Add formatter tests covering:
+   - `full_name` vs `first_name` + `last_name`
+   - `phone_number`
+   - `created_time`
+   - campaign fallback from assigned campaign
+   - answer inference from Meta-style question columns
+2. Update download tests to assert the exact canonical header order.
+3. Verify duplicate exports still include `reason`.
+
+## 9. Success Criteria
+
+- Exported clean lead files always use the same six columns in the approved order.
+- Duplicate files use the same six columns plus `reason`.
+- Existing batches with mixed payload keys can still be exported cleanly.
+- Meta Ads style uploads produce meaningful `answer`, `date`, `tel`, and `campaign` values without manual cleanup.

--- a/docs/plans/2026-03-08-leads-export-canonical-columns.md
+++ b/docs/plans/2026-03-08-leads-export-canonical-columns.md
@@ -1,0 +1,103 @@
+# Leads Export Canonical Columns Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Produce clean lead export CSVs with the canonical column order `full name, email, tel, answer, date, campaign` while preserving duplicate filtering and duplicate export reasons.
+
+**Architecture:** Keep import storage unchanged and normalize rows only when exporting. Add a shared export formatter that understands common Meta Ads header aliases, then route every clean and duplicate CSV builder through that formatter so new and historical downloads stay aligned.
+
+**Tech Stack:** React 18, Supabase JS, Vitest, Testing Library, Papa Parse, styled-components.
+
+---
+
+**Implementation guardrails**
+- Use @test-driven-development for each behavior change.
+- Use @verification-before-completion before claiming done.
+- Keep the scope limited to the leads import/export path.
+
+### Task 1: Cover canonical export mapping behavior
+
+**Files:**
+- Modify: `src/features/leads/hooks/__tests__/leadsApi.test.js`
+- Modify: `src/services/leadsApi.js`
+
+**Step 1: Write the failing test**
+
+Add tests proving `buildLeadsCsvText` emits:
+- `full name,email,tel,answer,date,campaign` for clean exports
+- `full name,email,tel,answer,date,campaign,reason` for duplicate exports
+- support for `full_name`
+- support for `first_name` + `last_name`
+- support for `phone_number`
+- support for `created_time`
+- support for explicit and inferred answer fields
+- campaign fallback from the assigned campaign name when payload data is missing
+
+**Step 2: Run test to verify it fails**
+
+Run: `npm run test -- src/features/leads/hooks/__tests__/leadsApi.test.js`
+Expected: FAIL because exports currently output `email` plus arbitrary payload keys.
+
+**Step 3: Write minimal implementation**
+
+Add a canonical export-row normalizer in `src/services/leadsApi.js` that:
+- resolves values through alias lists,
+- combines first and last name when needed,
+- excludes known system fields when inferring `answer`,
+- appends `reason` only for duplicate exports,
+- accepts optional campaign fallback context.
+
+**Step 4: Run test to verify it passes**
+
+Run: `npm run test -- src/features/leads/hooks/__tests__/leadsApi.test.js`
+Expected: PASS.
+
+### Task 2: Route all lead downloads through the canonical formatter
+
+**Files:**
+- Modify: `src/services/leadsApi.js`
+- Modify: `src/features/leads/admin/LeadsImportPreviewCard.jsx`
+- Modify: `src/features/leads/admin/AdminLeadImportsTable.jsx`
+- Modify: `src/pages/MyLeads.jsx`
+
+**Step 1: Write the failing test**
+
+Extend the leads API tests so historical batch downloads and generated files use the canonical headers even when rows only contain raw payload keys and a campaign fallback is required.
+
+**Step 2: Run test to verify it fails**
+
+Run: `npm run test -- src/features/leads/hooks/__tests__/leadsApi.test.js`
+Expected: FAIL because download helpers do not currently pass campaign context into the formatter.
+
+**Step 3: Write minimal implementation**
+
+- Update the clean and duplicate download helpers to pass campaign name when available.
+- Update stored-file generation during import confirm so `clean.csv` and `duplicates.csv` use the same canonical formatter.
+- Keep filenames and download behavior unchanged.
+
+**Step 4: Run test to verify it passes**
+
+Run: `npm run test -- src/features/leads/hooks/__tests__/leadsApi.test.js`
+Expected: PASS.
+
+### Task 3: Verify the targeted leads flow
+
+**Files:**
+- No code changes required if tests pass
+
+**Step 1: Run focused verification**
+
+Run: `npm run test -- src/features/leads/hooks/__tests__/leadsApi.test.js src/features/leads/admin/__tests__/LeadsImportPreviewCard.test.jsx src/features/leads/admin/__tests__/AdminLeadImportsTable.test.jsx src/features/leads/user/__tests__/MyLeadsTable.test.jsx`
+Expected: PASS.
+
+**Step 2: Run broader leads verification**
+
+Run: `npm run test -- src/features/leads`
+Expected: PASS.
+
+**Step 3: Review output**
+
+Check that:
+- clean CSV header order is fixed,
+- duplicate CSV adds `reason`,
+- campaign fallback works for rows with no campaign payload.

--- a/src/features/leads/admin/AdminLeadImportsTable.jsx
+++ b/src/features/leads/admin/AdminLeadImportsTable.jsx
@@ -77,14 +77,18 @@ function AdminLeadImportsTable() {
   async function handleDownloadNew(batch) {
     try {
       const base = getFilenameBase(batch.source_filename);
+      const campaignName =
+        batch?.campaign?.campaignName || `Campaign #${batch.campaign_id}`;
       if (batch.clean_file_path) {
         await downloadStoredLeadFile({
           path: batch.clean_file_path,
           filename: `${base}-batch-${batch.id}.csv`,
+          campaignName,
         });
       } else {
         await downloadLeadBatchCsv(batch.id, {
           filename: `${base}-batch-${batch.id}.csv`,
+          campaignName,
         });
       }
     } catch (error) {
@@ -100,10 +104,14 @@ function AdminLeadImportsTable() {
 
     try {
       const base = getFilenameBase(batch.source_filename);
+      const campaignName =
+        batch?.campaign?.campaignName || `Campaign #${batch.campaign_id}`;
       if (batch.duplicate_file_path) {
         await downloadStoredLeadFile({
           path: batch.duplicate_file_path,
           filename: `${base}-duplicates-batch-${batch.id}.csv`,
+          campaignName,
+          includeReason: true,
         });
       } else {
         const rows = await getLeadBatchDuplicateRows(batch.id);
@@ -114,6 +122,7 @@ function AdminLeadImportsTable() {
 
         downloadDuplicateLeadsCsv(rows, {
           filename: `${base}-duplicates-batch-${batch.id}.csv`,
+          campaignName,
         });
       }
     } catch (error) {

--- a/src/features/leads/admin/LeadsImportForm.jsx
+++ b/src/features/leads/admin/LeadsImportForm.jsx
@@ -96,6 +96,14 @@ function LeadsImportForm() {
     [activeCampaigns]
   );
 
+  const selectedCampaign = useMemo(
+    () =>
+      activeCampaigns.find(
+        (campaign) => String(campaign.id) === String(selectedCampaignId)
+      ) || null,
+    [activeCampaigns, selectedCampaignId]
+  );
+
   async function handlePreview(event) {
     event.preventDefault();
 
@@ -158,11 +166,15 @@ function LeadsImportForm() {
     const result = await confirmImport({
       assignedUserId: selectedUserId,
       campaignId: Number(selectedCampaignId),
+      campaignName: selectedCampaign?.campaignName || "",
       sourceFilename: file?.name || "leads.csv",
       rows: parsedRows,
     });
 
-    setImportResult(result);
+    setImportResult({
+      ...result,
+      campaign_name: selectedCampaign?.campaignName || "",
+    });
     if (result.storage_warning) {
       toast.error(result.storage_warning);
     } else {

--- a/src/features/leads/admin/LeadsImportPreviewCard.jsx
+++ b/src/features/leads/admin/LeadsImportPreviewCard.jsx
@@ -69,10 +69,12 @@ function LeadsImportPreviewCard({
         await downloadStoredLeadFile({
           path: importResult.clean_file_path,
           filename: `lead-batch-${importResult.batch_id}.csv`,
+          campaignName: importResult.campaign_name,
         });
       } else {
         await downloadLeadBatchCsv(importResult.batch_id, {
           filename: `lead-batch-${importResult.batch_id}.csv`,
+          campaignName: importResult.campaign_name,
         });
       }
     } catch (error) {
@@ -87,10 +89,13 @@ function LeadsImportPreviewCard({
         await downloadStoredLeadFile({
           path: importResult.duplicate_file_path,
           filename: `duplicate-leads-batch-${importResult.batch_id}.csv`,
+          campaignName: importResult.campaign_name,
+          includeReason: true,
         });
       } else {
         downloadDuplicateLeadsCsv(duplicateRows, {
           filename: `duplicate-leads-batch-${importResult.batch_id}.csv`,
+          campaignName: importResult.campaign_name,
         });
       }
     } catch (error) {

--- a/src/features/leads/admin/__tests__/AdminLeadImportsTable.test.jsx
+++ b/src/features/leads/admin/__tests__/AdminLeadImportsTable.test.jsx
@@ -129,7 +129,10 @@ describe("AdminLeadImportsTable", () => {
             payload_json: { name: "Dup" },
           },
         ],
-        { filename: "april-duplicates-batch-12.csv" }
+        {
+          filename: "april-duplicates-batch-12.csv",
+          campaignName: "Campaign B",
+        }
       );
     });
   });
@@ -162,6 +165,7 @@ describe("AdminLeadImportsTable", () => {
       expect(mockDownloadStoredLeadFile).toHaveBeenCalledWith({
         path: "users/u1/batches/14/clean.csv",
         filename: "may-batch-14.csv",
+        campaignName: "Campaign C",
       });
     });
     expect(mockDownloadLeadBatchCsv).not.toHaveBeenCalled();

--- a/src/features/leads/hooks/__tests__/leadsApi.test.js
+++ b/src/features/leads/hooks/__tests__/leadsApi.test.js
@@ -155,23 +155,53 @@ describe("leadsApi", () => {
     expect(out.storage_warning).toMatch(/storage down/i);
   });
 
-  it("builds duplicate csv with reason column", () => {
+  it("builds canonical csv columns from meta-style payload fields", () => {
+    const csv = buildLeadsCsvText(
+      [
+        {
+          email: "meta@example.com",
+          payload_json: {
+            first_name: "Philippe",
+            last_name: "Collet",
+            created_time: "2026-03-06T14:57:39-08:00",
+            phone_number: "p:+33603197653",
+            "cry sans jargon": "CRY SANS JARGON",
+            "quel_est_votre_niveau_actuel_concernant_les_cryptos_":
+              "je_decouvre_le_sujet",
+          },
+        },
+      ]
+    );
+
+    const [header, firstRow] = csv.split("\n");
+    expect(header).toBe("full name,email,tel,answer,date,campaign");
+    expect(firstRow).toBe(
+      '"Philippe Collet","meta@example.com","p:+33603197653","je_decouvre_le_sujet","2026-03-06T14:57:39-08:00","CRY SANS JARGON"'
+    );
+  });
+
+  it("builds duplicate csv with canonical columns and reason", () => {
     const csv = buildLeadsCsvText(
       [
         {
           email: "dup@example.com",
           reason: "duplicate_existing",
-          payload_json: { name: "Dup" },
+          payload_json: {
+            full_name: "Dup Lead",
+            phone_number: "111",
+            created_time: "2026-03-05T10:00:00Z",
+            response: "Interested",
+          },
         },
       ],
-      { includeReason: true }
+      { includeReason: true, campaignName: "Campaign Fallback" }
     );
 
     const [header, firstRow] = csv.split("\n");
-    expect(header).toBe("email,reason,name");
-    expect(firstRow).toContain('"dup@example.com"');
-    expect(firstRow).toContain('"duplicate_existing"');
-    expect(firstRow).toContain('"Dup"');
+    expect(header).toBe("full name,email,tel,answer,date,campaign,reason");
+    expect(firstRow).toBe(
+      '"Dup Lead","dup@example.com","111","Interested","2026-03-05T10:00:00Z","Campaign Fallback","duplicate_existing"'
+    );
   });
 
   it("downloads accepted leads csv with provided filename", () => {
@@ -226,16 +256,23 @@ describe("leadsApi", () => {
         {
           email: "dup@example.com",
           reason: "duplicate_existing",
-          payload_json: { name: "Dup Lead" },
+          payload_json: {
+            full_name: "Dup Lead",
+            phone_number: "111",
+            response: "Interested",
+            created_time: "2026-03-05T10:00:00Z",
+          },
         },
       ],
-      { filename: "duplicates.csv" }
+      { filename: "duplicates.csv", campaignName: "Campaign Fallback" }
     );
 
     const blobArg = createObjectURLSpy.mock.calls[0][0];
     expect(blobArg).toBeInstanceOf(Blob);
     const csvText = await blobArg.text();
-    expect(csvText.split("\n")[0]).toBe("email,reason,name");
+    expect(csvText.split("\n")[0]).toBe(
+      "full name,email,tel,answer,date,campaign,reason"
+    );
     expect(click).toHaveBeenCalledTimes(1);
     expect(revokeObjectURLSpy).toHaveBeenCalledWith("blob:duplicates");
   });
@@ -377,12 +414,22 @@ describe("leadsApi", () => {
   it("downloads full batch csv by paging reads beyond 1000 rows", async () => {
     const page1 = Array.from({ length: 1000 }, (_, index) => ({
       email: `lead-${index + 1}@example.com`,
-      payload_json: { source: "bulk" },
+      payload_json: {
+        full_name: `Lead ${index + 1}`,
+        phone_number: "111",
+        response: "bulk",
+        created_time: "2026-03-06T00:00:00Z",
+      },
     }));
     const page2 = [
       {
         email: "lead-1001@example.com",
-        payload_json: { source: "bulk" },
+        payload_json: {
+          full_name: "Lead 1001",
+          phone_number: "111",
+          response: "bulk",
+          created_time: "2026-03-06T00:00:00Z",
+        },
       },
     ];
 
@@ -416,14 +463,20 @@ describe("leadsApi", () => {
       .mockReturnValue("blob:batch");
     vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
 
-    await downloadLeadBatchCsv(12, { filename: "batch.csv" });
+    await downloadLeadBatchCsv(12, {
+      filename: "batch.csv",
+      campaignName: "Bulk Campaign",
+    });
 
     const blobArg = createObjectURLSpy.mock.calls[0][0];
     const csvText = await blobArg.text();
     const lines = csvText.split("\n");
 
     expect(lines).toHaveLength(1002);
-    expect(lines[0]).toBe("email,source");
+    expect(lines[0]).toBe("full name,email,tel,answer,date,campaign");
+    expect(lines[1]).toBe(
+      '"Lead 1","lead-1@example.com","111","bulk","2026-03-06T00:00:00Z","Bulk Campaign"'
+    );
     expect(query1.range).toHaveBeenCalledWith(0, 999);
     expect(query2.range).toHaveBeenCalledWith(1000, 1999);
     expect(click).toHaveBeenCalledTimes(1);
@@ -449,19 +502,26 @@ describe("leadsApi", () => {
     vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
     global.fetch.mockResolvedValue({
       ok: true,
-      blob: vi
+      text: vi
         .fn()
-        .mockResolvedValue(new Blob(["email\nstored@example.com"], { type: "text/csv" })),
+        .mockResolvedValue("email,full_name\nstored@example.com,Stored Lead"),
     });
 
     await downloadStoredLeadFile({
       path: "users/u1/batches/9/clean.csv",
       filename: "clean.csv",
+      campaignName: "Stored Campaign",
     });
 
     expect(createSignedUrl).toHaveBeenCalledWith("users/u1/batches/9/clean.csv", 60);
     expect(global.fetch).toHaveBeenCalledWith("https://signed.example/file.csv");
     expect(createObjectURLSpy).toHaveBeenCalledTimes(1);
+    const blobArg = createObjectURLSpy.mock.calls[0][0];
+    const csvText = await blobArg.text();
+    expect(csvText.split("\n")[0]).toBe("full name,email,tel,answer,date,campaign");
+    expect(csvText.split("\n")[1]).toBe(
+      '"Stored Lead","stored@example.com","","","","Stored Campaign"'
+    );
     expect(click).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/pages/MyLeads.jsx
+++ b/src/pages/MyLeads.jsx
@@ -31,8 +31,11 @@ function MyLeads() {
 
   async function handleDownload(batch) {
     try {
+      const campaignName =
+        batch?.campaign?.campaignName || `Campaign #${batch.campaign_id}`;
       await downloadLeadBatchCsv(batch.id, {
         filename: `${batch.source_filename.replace(/\.csv$/i, "")}-batch-${batch.id}.csv`,
+        campaignName,
       });
     } catch (error) {
       toast.error(error.message || "Could not download lead batch");

--- a/src/services/leadsApi.js
+++ b/src/services/leadsApi.js
@@ -1,7 +1,109 @@
 import supabase from "./supabase";
+import Papa from "papaparse";
 
 const PAGE_SIZE = 1000;
 const LEAD_IMPORT_FILES_BUCKET = "lead-import-files";
+const CANONICAL_EXPORT_HEADERS = [
+  "full name",
+  "email",
+  "tel",
+  "answer",
+  "date",
+  "campaign",
+];
+
+const FULL_NAME_ALIASES = buildAliasSet([
+  "full name",
+  "full_name",
+  "fullname",
+  "name",
+  "contact name",
+  "contact_name",
+]);
+const FIRST_NAME_ALIASES = buildAliasSet([
+  "first name",
+  "first_name",
+  "firstname",
+  "prenom",
+]);
+const LAST_NAME_ALIASES = buildAliasSet([
+  "last name",
+  "last_name",
+  "lastname",
+  "nom",
+  "surname",
+  "family name",
+  "family_name",
+]);
+const PHONE_ALIASES = buildAliasSet([
+  "tel",
+  "telephone",
+  "telephone num",
+  "telephone number",
+  "phone",
+  "phone number",
+  "phone_number",
+  "mobile",
+  "mobile phone",
+  "mobile_number",
+]);
+const DATE_ALIASES = buildAliasSet([
+  "date",
+  "created_time",
+  "created at",
+  "created_at",
+  "submitted at",
+  "submitted_at",
+  "submission time",
+  "submission_time",
+]);
+const CAMPAIGN_ALIASES = buildAliasSet([
+  "campaign",
+  "campaign name",
+  "campaign_name",
+  "campaignname",
+  "campaign title",
+  "campaign_title",
+  "ad campaign",
+  "ad_campaign",
+  "form name",
+  "form_name",
+  "lead form",
+  "lead_form",
+]);
+const ANSWER_ALIASES = buildAliasSet([
+  "answer",
+  "response",
+  "reply",
+  "lead answer",
+  "lead_answer",
+]);
+const SYSTEM_FIELD_ALIASES = buildAliasSet([
+  "email",
+  "e_mail",
+  "mail",
+  "id",
+  "lead id",
+  "lead_id",
+  "form id",
+  "form_id",
+  "ad id",
+  "ad_id",
+  "adset id",
+  "adset_id",
+  "campaign id",
+  "campaign_id",
+  "platform",
+  "source",
+  "utm source",
+  "utm_source",
+  "utm medium",
+  "utm_medium",
+  "utm campaign",
+  "utm_campaign",
+  "fbclid",
+  "gclid",
+]);
 
 async function fetchAllPages(buildQuery) {
   const rows = [];
@@ -27,6 +129,176 @@ async function fetchAllPages(buildQuery) {
 
 function buildCsvBlob(csvText) {
   return new Blob([csvText], { type: "text/csv;charset=utf-8;" });
+}
+
+function normalizeFieldKey(value) {
+  return String(value ?? "")
+    .trim()
+    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+function buildAliasSet(values) {
+  return new Set(values.map((value) => normalizeFieldKey(value)));
+}
+
+function stringifyCell(value) {
+  return String(value ?? "").trim();
+}
+
+function getRowEntries(row) {
+  const payloadEntries =
+    row?.payload_json && typeof row.payload_json === "object"
+      ? Object.entries(row.payload_json)
+      : [];
+  const topLevelEntries = Object.entries(row || {}).filter(
+    ([key]) => !["payload_json", "email", "reason"].includes(key)
+  );
+  const combinedEntries = [
+    ...payloadEntries,
+    ...topLevelEntries.filter(
+      ([key]) => !payloadEntries.some(([payloadKey]) => payloadKey === key)
+    ),
+  ];
+
+  return combinedEntries
+    .map(([key, value]) => ({
+      key,
+      normalizedKey: normalizeFieldKey(key),
+      value: stringifyCell(value),
+    }))
+    .filter((entry) => entry.value !== "");
+}
+
+function findEntryByAliases(entries, aliases) {
+  return entries.find((entry) => aliases.has(entry.normalizedKey)) || null;
+}
+
+function findValueByAliases(entries, aliases) {
+  return findEntryByAliases(entries, aliases)?.value || "";
+}
+
+function buildFullName(entries) {
+  const explicitName = findValueByAliases(entries, FULL_NAME_ALIASES);
+  if (explicitName) return explicitName;
+
+  return [findValueByAliases(entries, FIRST_NAME_ALIASES), findValueByAliases(entries, LAST_NAME_ALIASES)]
+    .filter(Boolean)
+    .join(" ");
+}
+
+function isMirroredLabelEntry(entry) {
+  if (!entry?.value) return false;
+  return normalizeFieldKey(entry.value) === entry.normalizedKey;
+}
+
+function isSystemFieldEntry(entry) {
+  const key = entry.normalizedKey;
+
+  if (
+    FULL_NAME_ALIASES.has(key) ||
+    FIRST_NAME_ALIASES.has(key) ||
+    LAST_NAME_ALIASES.has(key) ||
+    PHONE_ALIASES.has(key) ||
+    DATE_ALIASES.has(key) ||
+    CAMPAIGN_ALIASES.has(key) ||
+    ANSWER_ALIASES.has(key) ||
+    SYSTEM_FIELD_ALIASES.has(key)
+  ) {
+    return true;
+  }
+
+  return (
+    key === "email" ||
+    key.endsWith("_id") ||
+    key.startsWith("utm_") ||
+    key.includes("tracking") ||
+    key.includes("timestamp") ||
+    key.includes("created") ||
+    key.includes("submitted")
+  );
+}
+
+function scoreAnswerEntry(entry) {
+  let score = 0;
+  const key = entry.normalizedKey;
+
+  if (
+    /(answer|response|reply|question|qualif|niveau|level|goal|objectif|interest|interet|pourquoi|comment|quel|quelle|combien|what|which|how|why|when|where)/.test(
+      key
+    )
+  ) {
+    score += 5;
+  }
+
+  if (key.includes("_")) score += 1;
+  if (key.length >= 20) score += 2;
+  if (entry.value.length >= 4) score += 1;
+  if (isMirroredLabelEntry(entry)) score -= 3;
+
+  return score;
+}
+
+function buildAnswer(entries) {
+  const explicitAnswer = findValueByAliases(entries, ANSWER_ALIASES);
+  if (explicitAnswer) return explicitAnswer;
+
+  const candidateEntries = entries.filter(
+    (entry) => !isSystemFieldEntry(entry) && !isMirroredLabelEntry(entry)
+  );
+
+  if (!candidateEntries.length) return "";
+
+  return candidateEntries
+    .slice()
+    .sort((left, right) => {
+      const scoreDelta = scoreAnswerEntry(right) - scoreAnswerEntry(left);
+      if (scoreDelta !== 0) return scoreDelta;
+      return right.normalizedKey.length - left.normalizedKey.length;
+    })[0].value;
+}
+
+function buildCampaign(entries, fallbackCampaignName) {
+  const explicitCampaign = findValueByAliases(entries, CAMPAIGN_ALIASES);
+  if (explicitCampaign) return explicitCampaign;
+
+  const mirroredLabel = entries.find(
+    (entry) => !isSystemFieldEntry(entry) && isMirroredLabelEntry(entry)
+  );
+  if (mirroredLabel) return mirroredLabel.value;
+
+  return stringifyCell(fallbackCampaignName);
+}
+
+function mapLeadRowToExportRow(row, { campaignName } = {}) {
+  const entries = getRowEntries(row);
+
+  return {
+    "full name": buildFullName(entries),
+    email: stringifyCell(row?.email),
+    tel: findValueByAliases(entries, PHONE_ALIASES),
+    answer: buildAnswer(entries),
+    date: findValueByAliases(entries, DATE_ALIASES),
+    campaign: buildCampaign(entries, campaignName),
+    reason: stringifyCell(row?.reason),
+  };
+}
+
+function parseStoredLeadRows(csvText) {
+  const parsed = Papa.parse(csvText, {
+    header: true,
+    skipEmptyLines: true,
+  });
+
+  if (parsed.errors?.length) {
+    throw new Error("Could not parse stored lead file");
+  }
+
+  return parsed.data || [];
 }
 
 function triggerBlobDownload(blob, filename) {
@@ -59,6 +331,7 @@ export async function previewLeadImport({ assignedUserId, campaignId, emails }) 
 export async function confirmLeadImport({
   assignedUserId,
   campaignId,
+  campaignName,
   sourceFilename,
   rows,
 }) {
@@ -90,10 +363,14 @@ export async function confirmLeadImport({
 
     const cleanUpload = await supabase.storage
       .from(LEAD_IMPORT_FILES_BUCKET)
-      .upload(cleanFilePath, buildCsvBlob(buildLeadsCsvText(acceptedRows)), {
-        contentType: "text/csv;charset=utf-8;",
-        upsert: true,
-      });
+      .upload(
+        cleanFilePath,
+        buildCsvBlob(buildLeadsCsvText(acceptedRows, { campaignName })),
+        {
+          contentType: "text/csv;charset=utf-8;",
+          upsert: true,
+        }
+      );
 
     if (cleanUpload.error) throw new Error(cleanUpload.error.message);
 
@@ -105,6 +382,7 @@ export async function confirmLeadImport({
           buildCsvBlob(
             buildLeadsCsvText(data.duplicate_rows_export || [], {
               includeReason: true,
+              campaignName,
             })
           ),
           {
@@ -190,24 +468,20 @@ function escapeCsvValue(value) {
   return `"${escaped}"`;
 }
 
-export function buildLeadsCsvText(rows, { includeReason = false } = {}) {
-  const payloadKeys = Array.from(
-    rows.reduce((keys, row) => {
-      Object.keys(row.payload_json || {}).forEach((key) => keys.add(key));
-      return keys;
-    }, new Set())
-  );
-
-  const headers = ["email", ...(includeReason ? ["reason"] : []), ...payloadKeys];
+export function buildLeadsCsvText(
+  rows,
+  { includeReason = false, campaignName } = {}
+) {
+  const headers = [
+    ...CANONICAL_EXPORT_HEADERS,
+    ...(includeReason ? ["reason"] : []),
+  ];
   const lines = [
     headers.join(","),
-    ...rows.map((row) =>
-      [
-        escapeCsvValue(row.email),
-        ...(includeReason ? [escapeCsvValue(row.reason)] : []),
-        ...payloadKeys.map((key) => escapeCsvValue(row.payload_json?.[key])),
-      ].join(",")
-    ),
+    ...rows.map((row) => {
+      const exportRow = mapLeadRowToExportRow(row, { campaignName });
+      return headers.map((header) => escapeCsvValue(exportRow[header])).join(",");
+    }),
   ];
 
   return lines.join("\n");
@@ -217,28 +491,39 @@ function triggerCsvDownload(csvText, filename) {
   triggerBlobDownload(buildCsvBlob(csvText), filename);
 }
 
-export function downloadAcceptedLeadsCsv(rows, { filename }) {
-  const csvText = buildLeadsCsvText(rows, { includeReason: false });
+export function downloadAcceptedLeadsCsv(
+  rows,
+  { filename, campaignName } = {}
+) {
+  const csvText = buildLeadsCsvText(rows, { campaignName });
   triggerCsvDownload(csvText, filename || "accepted-leads.csv");
 }
 
-export function downloadDuplicateLeadsCsv(rows, { filename }) {
-  const csvText = buildLeadsCsvText(rows, { includeReason: true });
+export function downloadDuplicateLeadsCsv(rows, { filename, campaignName } = {}) {
+  const csvText = buildLeadsCsvText(rows, {
+    includeReason: true,
+    campaignName,
+  });
   triggerCsvDownload(csvText, filename || "duplicate-leads.csv");
 }
 
-export async function downloadLeadBatchCsv(batchId, { filename } = {}) {
+export async function downloadLeadBatchCsv(batchId, { filename, campaignName } = {}) {
   const data = await getLeadBatchAcceptedRows(batchId);
 
   if (!data?.length) {
     throw new Error("No leads found for this batch");
   }
 
-  const csvText = buildLeadsCsvText(data);
+  const csvText = buildLeadsCsvText(data, { campaignName });
   triggerCsvDownload(csvText, filename || `lead-batch-${batchId}.csv`);
 }
 
-export async function downloadStoredLeadFile({ path, filename }) {
+export async function downloadStoredLeadFile({
+  path,
+  filename,
+  campaignName,
+  includeReason = false,
+}) {
   const { data, error } = await supabase.storage
     .from(LEAD_IMPORT_FILES_BUCKET)
     .createSignedUrl(path, 60);
@@ -253,6 +538,10 @@ export async function downloadStoredLeadFile({ path, filename }) {
     throw new Error("Could not download stored lead file");
   }
 
-  const blob = await response.blob();
-  triggerBlobDownload(blob, filename);
+  const csvText = await response.text();
+  const rows = parseStoredLeadRows(csvText);
+  triggerCsvDownload(
+    buildLeadsCsvText(rows, { includeReason, campaignName }),
+    filename
+  );
 }


### PR DESCRIPTION
## Summary
- normalize lead export downloads to canonical columns: `full name, email, tel, answer, date, campaign`
- keep duplicate exports in the same shape with `reason` appended and pass campaign fallback through all download paths
- add Meta-style alias handling for name, phone, date, campaign, and answer fields, plus design notes for the change

## Verification
- `npm run test -- src/features/leads`
- `npm run build`
- live local browser QA against Docker-backed Supabase: uploaded Meta-style first/last-name, full-name duplicate, and email-only CSVs and verified the downloaded CSV output