### PR TITLE
fix(leads): support french meta aliases

### DIFF
--- a/src/features/leads/hooks/__tests__/leadsApi.test.js
+++ b/src/features/leads/hooks/__tests__/leadsApi.test.js
@@ -204,6 +204,44 @@ describe("leadsApi", () => {
     );
   });
 
+  it("supports french meta export aliases for name and phone fields", () => {
+    const csv = buildLeadsCsvText(
+      [
+        {
+          email: "french@example.com",
+          payload_json: {
+            nom_complet: "Christian Nicouleau",
+            numéro_de_téléphone: "p:+33609281321",
+            created_time: "2026-03-07T11:31:06-05:00",
+            "quel_est_votre_niveau_d’expérience_en_bourse_?_📈":
+              "3️⃣_j’ai_déjà_acheté_quelques_actions",
+            campaign_name: "ACHAT DAS 06/03/26",
+          },
+        },
+        {
+          email: "split@example.com",
+          payload_json: {
+            prénom: "Herve",
+            nom_de_famille: "Spierckel",
+            numéro_de_téléphone: "p:+33685832381",
+            created_time: "2026-03-07T23:47:31+08:00",
+            "❓_quelle_est_votre_situation_vis-à-vis_des_cryptomonnaies_?":
+              "🆕_je_découvre_le_sujet_et_souhaite_comprendre_les_bases",
+            campaign_name: "EXPLICA. CRY Z - 09/02/26",
+          },
+        },
+      ]
+    );
+
+    const [, firstRow, secondRow] = csv.split("\n");
+    expect(firstRow).toBe(
+      '"Christian Nicouleau","french@example.com","p:+33609281321","3️⃣_j’ai_déjà_acheté_quelques_actions","2026-03-07T11:31:06-05:00","ACHAT DAS 06/03/26"'
+    );
+    expect(secondRow).toBe(
+      '"Herve Spierckel","split@example.com","p:+33685832381","🆕_je_découvre_le_sujet_et_souhaite_comprendre_les_bases","2026-03-07T23:47:31+08:00","EXPLICA. CRY Z - 09/02/26"'
+    );
+  });
+
   it("downloads accepted leads csv with provided filename", () => {
     const realCreateElement = document.createElement.bind(document);
     const click = vi.fn();

--- a/src/services/leadsApi.js
+++ b/src/services/leadsApi.js
@@ -19,12 +19,15 @@ const FULL_NAME_ALIASES = buildAliasSet([
   "name",
   "contact name",
   "contact_name",
+  "nom complet",
+  "nom_complet",
 ]);
 const FIRST_NAME_ALIASES = buildAliasSet([
   "first name",
   "first_name",
   "firstname",
   "prenom",
+  "prénom",
 ]);
 const LAST_NAME_ALIASES = buildAliasSet([
   "last name",
@@ -34,6 +37,8 @@ const LAST_NAME_ALIASES = buildAliasSet([
   "surname",
   "family name",
   "family_name",
+  "nom de famille",
+  "nom_de_famille",
 ]);
 const PHONE_ALIASES = buildAliasSet([
   "tel",
@@ -46,6 +51,11 @@ const PHONE_ALIASES = buildAliasSet([
   "mobile",
   "mobile phone",
   "mobile_number",
+  "numero de telephone",
+  "numero_de_telephone",
+  "numéro de téléphone",
+  "numéro_de_téléphone",
+  "portable",
 ]);
 const DATE_ALIASES = buildAliasSet([
   "date",


### PR DESCRIPTION
## Summary
- add French Meta lead field aliases for full name, split name, and phone detection in lead exports
- cover `nom_complet`, `nom_de_famille`, `prénom`, and `numéro_de_téléphone` with a regression test using real upload shapes
- keep upload behavior unchanged while preventing blank `full name` and `tel` values in exported CSVs

## Test plan
- [x] `npm run lint`
- [x] `npm run test`
- [x] `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)